### PR TITLE
BP 2.7 compatibility and other fixes

### DIFF
--- a/bpge-search.php
+++ b/bpge-search.php
@@ -116,17 +116,18 @@ function bpges_search_get_groups() {
 	global $wpdb, $bpge;
 
 	// get the search terms
+	$query_arg = bp_core_get_component_search_query_arg( 'groups' );
 	if ( isset( $_REQUEST['search_terms'] ) && ! empty( $_REQUEST['search_terms'] ) ) {
 		$search_terms = strip_tags( trim( $_REQUEST['search_terms'] ) );
-		// ajax
-		$search_terms = esc_sql( $wpdb->esc_like( $search_terms ) );
 	} elseif ( isset( $_REQUEST['s'] ) && ! empty( $_REQUEST['s'] ) ) {
 		$search_terms = strip_tags( trim( $_REQUEST['s'] ) );
-		// url-based
-		$search_terms = esc_sql( $wpdb->esc_like( $search_terms ) );
+	} elseif ( ! empty( $_REQUEST[ $query_arg ] ) )  {
+		$search_terms = trim( wp_unslash( $_REQUEST[ $query_arg ] ) );
 	} else {
 		return false;
 	}
+
+	$search_terms = '%' . $wpdb->esc_like( $search_terms ) . '%';
 
 	$pages            = $fields = array();
 	$pages_groups_ids = $fields_groups_ids = array();
@@ -144,8 +145,8 @@ function bpges_search_get_groups() {
                           AND p.post_status = 'publish'
                           AND p.post_type = '%s'
                           AND p.post_parent > 0
-                          AND (p.post_title LIKE '%%%s%%'
-                                OR p.post_content COLLATE UTF8_GENERAL_CI LIKE '%%%s%%'
+                          AND (p.post_title LIKE %s
+                                OR p.post_content COLLATE UTF8_GENERAL_CI LIKE %s'
                               )", $type, $search_terms, $search_terms ) );
 	}
 	foreach ( $pages as $data ) {
@@ -158,11 +159,11 @@ function bpges_search_get_groups() {
 		$type   = BPGE_GFIELDS;
 		$fields = $wpdb->get_results( $wpdb->prepare(
 			"SELECT DISTINCT (post_parent) AS group_id, post_name, post_title
-            FROM wp_posts
-            WHERE post_type = '%s'
-              AND post_status = 'publish'
-              AND post_parent > 0
-              AND post_content COLLATE UTF8_GENERAL_CI LIKE '%%%s%%';", $type, $search_terms ) );
+			FROM wp_posts
+			WHERE post_type = '%s'
+			  AND post_status = 'publish'
+			  AND post_parent > 0
+			  AND post_content COLLATE UTF8_GENERAL_CI LIKE %s;", $type, $search_terms ) );
 	}
 	foreach ( $fields as $data ) {
 		$fields_groups_ids[]             = $data->group_id;

--- a/bpge-search.php
+++ b/bpge-search.php
@@ -45,8 +45,8 @@ add_action( 'admin_init', 'bpges_remove_cron' );
  * Intrude into get_groups sql
  */
 function bpges_init() {
-	add_filter( 'bp_groups_get_paged_groups_sql', 'bpges_search_add_paged', 1, 2 );
-	add_filter( 'bp_groups_get_total_groups_sql', 'bpges_search_add_total', 1, 2 );
+	add_filter( 'bp_groups_get_paged_groups_sql', 'bpges_search_add_paged', 1, 3 );
+	add_filter( 'bp_groups_get_total_groups_sql', 'bpges_search_add_total', 1, 3 );
 }
 
 add_action( 'plugins_loaded', 'bpges_init', 999 );
@@ -182,11 +182,12 @@ function bpges_search_get_groups() {
  *
  * @param $sql_str
  * @param $sql_arr
+ * @param $query_args
  *
  * @return string
  */
-function bpges_search_add_paged( $sql_str, $sql_arr ) {
-	if ( ! isset( $sql_arr['search'] ) ) {
+function bpges_search_add_paged( $sql_str, $sql_arr, $query_args ) {
+	if ( empty( $query_args['search_terms'] ) ) {
 		return $sql_str;
 	}
 
@@ -209,17 +210,17 @@ function bpges_search_add_paged( $sql_str, $sql_arr ) {
  *
  * @param string $sql_str
  * @param string $sql_arr
+ * @param array $query_args
  *
  * @return mixed
  */
 function bpges_search_add_total(
 	$sql_str,
 	/** @noinspection PhpUnusedParameterInspection */
-	$sql_arr
+	$sql_arr,
+	$query_args
 ) {
-	// check that we are in a search
-	$pos = strpos( $sql_str, 'g.name LIKE' );
-	if ( $pos === false ) {
+	if ( empty( $query_args['search_terms'] ) ) {
 		return $sql_str;
 	}
 

--- a/bpge-search.php
+++ b/bpge-search.php
@@ -111,20 +111,22 @@ add_action( 'bp_directory_groups_item', 'bpges_display_extra_results' );
 /**
  * Search in posts and fields for group IDs
  */
-function bpges_search_get_groups() {
+function bpges_search_get_groups( $search_terms = null ) {
 	/** @var $wpdb WPDB */
 	global $wpdb, $bpge;
 
 	// get the search terms
-	$query_arg = bp_core_get_component_search_query_arg( 'groups' );
-	if ( isset( $_REQUEST['search_terms'] ) && ! empty( $_REQUEST['search_terms'] ) ) {
-		$search_terms = strip_tags( trim( $_REQUEST['search_terms'] ) );
-	} elseif ( isset( $_REQUEST['s'] ) && ! empty( $_REQUEST['s'] ) ) {
-		$search_terms = strip_tags( trim( $_REQUEST['s'] ) );
-	} elseif ( ! empty( $_REQUEST[ $query_arg ] ) )  {
-		$search_terms = trim( wp_unslash( $_REQUEST[ $query_arg ] ) );
-	} else {
-		return false;
+	if ( null === $search_terms ) {
+		$query_arg = bp_core_get_component_search_query_arg( 'groups' );
+		if ( isset( $_REQUEST['search_terms'] ) && ! empty( $_REQUEST['search_terms'] ) ) {
+			$search_terms = strip_tags( trim( $_REQUEST['search_terms'] ) );
+		} elseif ( isset( $_REQUEST['s'] ) && ! empty( $_REQUEST['s'] ) ) {
+			$search_terms = strip_tags( trim( $_REQUEST['s'] ) );
+		} elseif ( ! empty( $_REQUEST[ $query_arg ] ) )  {
+			$search_terms = trim( wp_unslash( $_REQUEST[ $query_arg ] ) );
+		} else {
+			return false;
+		}
 	}
 
 	$search_terms = '%' . $wpdb->esc_like( $search_terms ) . '%';
@@ -193,7 +195,7 @@ function bpges_search_add_paged( $sql_str, $sql_arr, $query_args ) {
 	}
 
 	// get all groups that have pages/fiels that are good for this search
-	$results    = bpges_search_get_groups();
+	$results    = bpges_search_get_groups( $query_args['search_terms'] );
 	$groups_ids = $results['groups_ids'];
 
 	if ( ! empty( $groups_ids ) ) {
@@ -226,7 +228,7 @@ function bpges_search_add_total(
 	}
 
 	// get all groups that have pages/fiels that are good for this search
-	$results    = bpges_search_get_groups();
+	$results    = bpges_search_get_groups( $query_args['search_terms'] );
 	$groups_ids = $results['groups_ids'];
 
 	if ( ! empty( $groups_ids ) ) {

--- a/bpge-search.php
+++ b/bpge-search.php
@@ -154,7 +154,7 @@ function bpges_search_get_groups( $search_terms = null ) {
                           AND p.post_type = '%s'
                           AND p.post_parent > 0
                           AND (p.post_title LIKE %s
-                                OR p.post_content COLLATE UTF8_GENERAL_CI LIKE %s'
+                                OR p.post_content LIKE %s'
                               )", $type, $search_terms_sql, $search_terms_sql ) );
 	}
 	foreach ( $pages as $data ) {
@@ -171,7 +171,7 @@ function bpges_search_get_groups( $search_terms = null ) {
 			WHERE post_type = '%s'
 			  AND post_status = 'publish'
 			  AND post_parent > 0
-			  AND post_content COLLATE UTF8_GENERAL_CI LIKE %s;", $type, $search_terms_sql ) );
+			  AND post_content LIKE %s;", $type, $search_terms_sql ) );
 	}
 	foreach ( $fields as $data ) {
 		$fields_groups_ids[]             = $data->group_id;


### PR DESCRIPTION
Hi @slaFFik - Sorry for the big PR, but a number of my fixes were dependent on each other. Let me know if you'd like me to break it up.

For c78d5f8, see https://buddypress.trac.wordpress.org/ticket/5451

7610ebe probably won't be necessary in 2.7 as a result of https://buddypress.trac.wordpress.org/ticket/5451 (which adds its own layer of caching) but it still seemed like a nice thing to do :)

c35e814 - I assume that you added this `COLLATE` line to force queries to be case-insensitive. Is that correct? Calling this specific `COLLATE` breaks the query on some charsets, including the new default utf8mb4. If you need to force case-insensitivity on some charsets, you'll need to do a conditional `COLLATE`, checking the existing collation first and being sure to `COLLATE` to a collation that's available for the table's charset. The `wpdb` query class in WP has some code you might study for more information.
